### PR TITLE
Test + Bench packet parsing

### DIFF
--- a/bench/PacketParserBench.re
+++ b/bench/PacketParserBench.re
@@ -1,0 +1,42 @@
+open BenchFramework;
+
+open Exthost.Transport.Packet;
+
+let options = Reperf.Options.create(~iterations=100, ());
+
+module Constants = {
+  let individualPacketSize = 8192;
+  let packetCount = 100;
+  let totalSize = packetCount * individualPacketSize;
+};
+
+let largeBody =
+  String.make(Constants.individualPacketSize, 'a')
+  |> Bytes.of_string
+  |> Luv.Buffer.from_bytes;
+let header =
+  Header.{packetType: Regular, id: 0, ack: 0, length: Constants.totalSize}
+  |> Header.toBytes
+  |> Luv.Buffer.from_bytes;
+
+let parseLargeMessage = () => {
+  let (p, _messages) = Parser.initial |> Parser.parse(header);
+
+  let parser = ref(p);
+
+  for (_idx in 0 to Constants.packetCount - 1) {
+    let p = parser^;
+    let (newParser, _messages) = Parser.parse(largeBody, p);
+    parser := newParser;
+  };
+};
+
+let setup = () => ();
+
+bench(
+  ~name="Packet parser bench",
+  ~options,
+  ~setup,
+  ~f=parseLargeMessage,
+  (),
+);

--- a/bench/dune
+++ b/bench/dune
@@ -4,4 +4,5 @@
     (ocamlopt_flags -linkall)
     (libraries
       reperf.lib
+      vscode-exthost
 ))

--- a/src/Transport/Transport.re
+++ b/src/Transport/Transport.re
@@ -118,7 +118,7 @@ module Packet = {
     let p1Bytes = toBytes(p1);
     let p2Bytes = toBytes(p2);
     Bytes.equal(p1Bytes, p2Bytes);
-  }
+  };
 
   module Parser = {
     type state =
@@ -127,14 +127,15 @@ module Packet = {
 
     type t = {
       state,
-      bytes: Bytes.t,
+      bytes,
     };
 
     type parser = t;
 
     let initial = {state: WaitingForHeader, bytes: Bytes.create(0)};
 
-    let addBytes = (bytes: Bytes.t, parser) => {
+    let addBuffer = (buffer: Luv.Buffer.t, parser) => {
+      let bytes = Luv.Buffer.to_bytes(buffer);
       let bytes = Bytes.cat(parser.bytes, bytes);
       {...parser, bytes};
     };
@@ -181,9 +182,7 @@ module Packet = {
     };
 
     let parse = (buffer, initialParser) => {
-      let bytes = Luv.Buffer.to_bytes(buffer);
-
-      let parser = addBytes(bytes, initialParser);
+      let parser = addBuffer(buffer, initialParser);
 
       let canParseMore = parser => {
         switch (parser.state) {

--- a/src/Transport/Transport.rei
+++ b/src/Transport/Transport.rei
@@ -33,9 +33,9 @@ module Packet: {
     type parser;
 
     let initial: parser;
-    
+
     let parse: (Luv.Buffer.t, parser) => (parser, list(t));
-  }
+  };
 };
 
 [@deriving show]

--- a/src/Transport/Transport.rei
+++ b/src/Transport/Transport.rei
@@ -26,6 +26,16 @@ module Packet: {
   };
 
   let create: (~bytes: Bytes.t, ~packetType: packetType, ~id: int) => t;
+  let toBytes: t => bytes;
+  let equal: (t, t) => bool;
+
+  module Parser: {
+    type parser;
+
+    let initial: parser;
+    
+    let parse: (Luv.Buffer.t, parser) => (parser, list(t));
+  }
 };
 
 [@deriving show]

--- a/test/Transport/PacketParserTest.re
+++ b/test/Transport/PacketParserTest.re
@@ -1,0 +1,40 @@
+open TestFramework;
+open Exthost;
+
+module Packet = Transport.Packet;
+module Parser = Transport.Packet.Parser;
+
+open Packet;
+
+let simpleMessage1 = "Hello World!" |> Bytes.of_string;
+let simpleMessage2 = "Hello World2!" |> Bytes.of_string;
+
+let packet1 = Packet.create(~bytes=simpleMessage1, ~packetType=Regular, ~id=1);
+let packet2 = Packet.create(~bytes=simpleMessage2, ~packetType=Regular, ~id=2);
+
+let packet1Bytes = Packet.toBytes(packet1);
+let packet1Buffer = packet1Bytes |> Luv.Buffer.from_bytes;
+
+let packet1Split1 = Bytes.sub(packet1Bytes, 0, 4) |> Luv.Buffer.from_bytes;
+let packet1Split2 = Bytes.sub(packet1Bytes, 4, Bytes.length(packet1Bytes) - 4) |> Luv.Buffer.from_bytes;
+
+describe("Transport.Packet.parser", ({test, _}) => {
+  test("simple, full message packet", ({expect}) => {
+    let (_parser, messages) = Parser.initial
+    |> Parser.parse(packet1Buffer);
+
+    expect.bool(Packet.equal(messages |> List.hd, packet1)).toBe(true);
+  })
+  test("split packet", ({expect}) => {
+
+    let (parser, messages) = Parser.initial
+    |> Parser.parse(packet1Split1);
+
+    expect.equal(messages, []);
+
+    let (_parser, messages) = parser
+    |> Parser.parse(packet1Split2);
+
+    expect.bool(Packet.equal(messages |> List.hd, packet1)).toBe(true);
+  })
+});

--- a/test/Transport/PacketParserTest.re
+++ b/test/Transport/PacketParserTest.re
@@ -9,32 +9,49 @@ open Packet;
 let simpleMessage1 = "Hello World!" |> Bytes.of_string;
 let simpleMessage2 = "Hello World2!" |> Bytes.of_string;
 
-let packet1 = Packet.create(~bytes=simpleMessage1, ~packetType=Regular, ~id=1);
-let packet2 = Packet.create(~bytes=simpleMessage2, ~packetType=Regular, ~id=2);
+let packet1 =
+  Packet.create(~bytes=simpleMessage1, ~packetType=Regular, ~id=1);
+let packet2 =
+  Packet.create(~bytes=simpleMessage2, ~packetType=Regular, ~id=2);
 
 let packet1Bytes = Packet.toBytes(packet1);
+let packet1Length = packet1Bytes |> Bytes.length;
 let packet1Buffer = packet1Bytes |> Luv.Buffer.from_bytes;
 
 let packet1Split1 = Bytes.sub(packet1Bytes, 0, 4) |> Luv.Buffer.from_bytes;
-let packet1Split2 = Bytes.sub(packet1Bytes, 4, Bytes.length(packet1Bytes) - 4) |> Luv.Buffer.from_bytes;
+let packet1Split2 =
+  Bytes.sub(packet1Bytes, 4, Bytes.length(packet1Bytes) - 4)
+  |> Luv.Buffer.from_bytes;
+
+let doublePackets = Bytes.create(packet1Length * 2);
+Bytes.blit(packet1Bytes, 0, doublePackets, 0, packet1Length);
+Bytes.blit(packet1Bytes, 0, doublePackets, packet1Length, packet1Length);
+let doublePacketBuffer = doublePackets |> Luv.Buffer.from_bytes;
 
 describe("Transport.Packet.parser", ({test, _}) => {
   test("simple, full message packet", ({expect}) => {
-    let (_parser, messages) = Parser.initial
-    |> Parser.parse(packet1Buffer);
+    let (_parser, messages) = Parser.initial |> Parser.parse(packet1Buffer);
 
     expect.bool(Packet.equal(messages |> List.hd, packet1)).toBe(true);
-  })
+  });
   test("split packet", ({expect}) => {
-
-    let (parser, messages) = Parser.initial
-    |> Parser.parse(packet1Split1);
+    let (parser, messages) = Parser.initial |> Parser.parse(packet1Split1);
 
     expect.equal(messages, []);
 
-    let (_parser, messages) = parser
-    |> Parser.parse(packet1Split2);
+    let (_parser, messages) = parser |> Parser.parse(packet1Split2);
 
     expect.bool(Packet.equal(messages |> List.hd, packet1)).toBe(true);
-  })
+  });
+  test("double packets", ({expect}) => {
+    let (_parser, messages) =
+      Parser.initial |> Parser.parse(doublePacketBuffer);
+
+    expect.int(List.length(messages)).toBe(2);
+
+    let p1 = List.nth(messages, 0);
+    let p2 = List.nth(messages, 1);
+    expect.bool(Packet.equal(p1, packet1)).toBe(true);
+    expect.bool(Packet.equal(p2, packet1)).toBe(true);
+  });
 });


### PR DESCRIPTION
This adds some test cases and an initial benchmark to help guide improving the performance of the transport layer.

At the moment, the way we are handling packets is very heavy in terms of GC and allocations, because of the extraneous allocations and concatenations we're doing in the naive packet parser implementation. 

The tests + benchmarks will help guide a more efficient implementation.

Initial benchmark results:
```
+----------------------------------------------------------------------------------------------------------------------------------+
|  BENCHMARK            |  ITERATIONS |  TIME               |  MINOR GC  |  MAJOR GC  |  MINOR ALLOC  |  PROMOTED  |  MAJOR ALLOC  |
|-----------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Packet parser bench  |  100        |  1.49336194992      |  1850      |  639       |  309611       |  5084      |  537645284    |
|-----------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```