### PR TITLE
API: Remove On* prefix from commands

### DIFF
--- a/src/ExtensionService.re
+++ b/src/ExtensionService.re
@@ -4,8 +4,8 @@ type msg =
       extensionId: string,
       activationEvent: option(string),
     })
-  | OnWillActivateExtension({extensionId: string})
-  | OnDidActivateExtension({
+  | WillActivateExtension({extensionId: string})
+  | DidActivateExtension({
       extensionId: string,
       //startup: bool,
       codeLoadingTime: int,
@@ -13,11 +13,11 @@ type msg =
       activateResolvedTime: int,
     })
   //activationEvent: option(string),
-  | OnExtensionActivationError({
+  | ExtensionActivationError({
       extensionId: string,
       errorMessage: string,
     })
-  | OnExtensionRuntimeError({extensionId: string});
+  | ExtensionRuntimeError({extensionId: string});
 // TODO: Error?
 
 let handle = (method, args: Yojson.Safe.t) => {
@@ -39,9 +39,9 @@ let handle = (method, args: Yojson.Safe.t) => {
       "$onExtensionActivationError",
       `List([`String(extensionId), `String(errorMessage)]),
     ) =>
-    Ok(OnExtensionActivationError({extensionId, errorMessage}))
+    Ok(ExtensionActivationError({extensionId, errorMessage}))
   | ("$onWillActivateExtension", `List([`String(extensionId)])) =>
-    Ok(OnWillActivateExtension({extensionId: extensionId}))
+    Ok(WillActivateExtension({extensionId: extensionId}))
   | (
       "$onDidActivateExtension",
       `List([
@@ -53,7 +53,7 @@ let handle = (method, args: Yojson.Safe.t) => {
       ]),
     ) =>
     Ok(
-      OnDidActivateExtension({
+      DidActivateExtension({
         extensionId,
         codeLoadingTime,
         activateCallTime,
@@ -61,7 +61,7 @@ let handle = (method, args: Yojson.Safe.t) => {
       }),
     )
   | ("$onExtensionRuntimeError", `List([`String(extensionId), ..._args])) =>
-    Ok(OnExtensionRuntimeError({extensionId: extensionId}))
+    Ok(ExtensionRuntimeError({extensionId: extensionId}))
   | _ => Error("Unhandled method: " ++ method)
   };
 };

--- a/src/Exthost.rei
+++ b/src/Exthost.rei
@@ -26,8 +26,8 @@ module ExtensionService: {
         extensionId: string,
         activationEvent: option(string),
       })
-    | OnWillActivateExtension({extensionId: string})
-    | OnDidActivateExtension({
+    | WillActivateExtension({extensionId: string})
+    | DidActivateExtension({
         extensionId: string,
         //startup: bool,
         codeLoadingTime: int,
@@ -35,11 +35,11 @@ module ExtensionService: {
         activateResolvedTime: int,
       })
     //activationEvent: option(string),
-    | OnExtensionActivationError({
+    | ExtensionActivationError({
         extensionId: string,
         errorMessage: string,
       })
-    | OnExtensionRuntimeError({extensionId: string});
+    | ExtensionRuntimeError({extensionId: string});
   // TODO: Error?
 };
 

--- a/test/ActivationEventsTest.re
+++ b/test/ActivationEventsTest.re
@@ -7,7 +7,7 @@ describe("ActivationEventsTest", ({test, _}) => {
     test("close - extensions", _ => {
       let waitForActivation =
         fun
-        | Msg.ExtensionService(OnDidActivateExtension({extensionId, _})) =>
+        | Msg.ExtensionService(DidActivateExtension({extensionId, _})) =>
           extensionId == "oni-always-activate"
         | _ => false;
 

--- a/test/lib/Waiter.re
+++ b/test/lib/Waiter.re
@@ -1,4 +1,4 @@
-let wait = (~timeout=1.0, ~name="TODO", condition) => {
+let wait = (~timeout=5.0, ~name="TODO", condition) => {
   let start = Unix.gettimeofday();
   let delta = () => Unix.gettimeofday() -. start;
 


### PR DESCRIPTION
@glennsl , this is to follow up on our discussion here: https://github.com/onivim/reason-vscode-exthost/pull/17#discussion_r415266855

Should we use the same naming convention as VSCode's protocol, so that we have 1-to-1 parity with the naming? Or remove the `On*` prefix to alleviate confusion, but skip out on that 1-to-1 parity with names?